### PR TITLE
Adaptation pour une meilleure prise en compte de l'utf-8

### DIFF
--- a/divers/outils/database.php
+++ b/divers/outils/database.php
@@ -205,7 +205,7 @@ elseif($user) {
         $sql.= $db->qstr($actif).', ';
         $sql.= $db->qstr($acl).', ';
         $sql.= $db->qstr($poste).', ';
-        $sql.= $db->qstr(strtoupper(delete_accent($nom))).', ';
+        $sql.= $db->qstr(mb_strtoupper(delete_accent($nom),'UTF-8')).', ';
         $sql.= $db->qstr($prenom).', ';
         $sql.= $db->qstr($email).', ';
         $sql.= $db->qstr(hash('sha512', $password)).', ';

--- a/divers/outils/database.php
+++ b/divers/outils/database.php
@@ -188,8 +188,8 @@ elseif($user) {
         $poste=$tableau_poste[array_rand($tableau_poste, 1)];
         $nom=trim($tableau_nom[array_rand($tableau_nom, 1)]);
         $prenom=trim($tableau_nom[array_rand($tableau_nom, 1)]);
-        $email=strtolower(delete_accent($prenom).'.'.delete_accent($nom).'@globalis-ms.com');
-        $password=strtolower(delete_accent($prenom));
+        $email=mb_strtolower(delete_accent($prenom).'.'.delete_accent($nom).'@globalis-ms.com','UTF-8');
+        $password=mb_strtolower(delete_accent($prenom),'UTF-8');
         $couleur=trim($tableau_couleur[array_rand($tableau_couleur, 1)]);
         $theme=$tableau_theme[array_rand($tableau_theme, 1)];
         $langue=$tableau_langue[array_rand($tableau_langue, 1)];

--- a/divers/outils/decouplage.php
+++ b/divers/outils/decouplage.php
@@ -171,7 +171,7 @@ foreach($decouplage as $file => $replace) {
             if($key!='CARBONE')
                 $new=str_replace($key, str_replace('%s', $var, $value), $new, $count);
             else
-                $new=str_replace($key, str_replace('%s', strtoupper($var), $value), $new, $count);
+                $new=str_replace($key, str_replace('%s', mb_strtoupper($var,'UTF-8'), $value), $new, $count);
             $total+=$count;
         }
         if($total!==$check) {

--- a/divers/outils/decouplage.php
+++ b/divers/outils/decouplage.php
@@ -116,7 +116,7 @@ $bug=0;
 $tmp=substr($_SERVER['PWD'], 0, strpos($_SERVER['PWD'], '/divers/outils'));
 $root=dirname($tmp);
 $avant='/'.basename($tmp);
-$apres=substr($destination, strlen($root));
+$apres=substr($destination, mb_strlen($root,'UTF-8'));
 
 foreach(array($fo, $bo) as $var) {
     $file=$destination.'/'.$var.'/.htaccess';

--- a/divers/outils/jsmin.php
+++ b/divers/outils/jsmin.php
@@ -72,7 +72,7 @@ if(!$arg || $help==TRUE) {
 $js=file_get_contents($source);
 
 if($debug) {
-    $tmp=strlen($js);
+    $tmp=mb_strlen($js,'UTF-8');
 
     $kilo=(int)(($tmp)/(1024));
     $byte=($tmp)%(1024);
@@ -88,7 +88,7 @@ if($debug) {
 $jsmin=JSMin::minify($js);
 
 if($debug) {
-    $tmp=strlen($jsmin);
+    $tmp=mb_strlen($jsmin,'UTF-8');
 
     $kilo=(int)(($tmp)/(1024));
     $byte=($tmp)%(1024);

--- a/divers/outils/local_lib.php
+++ b/divers/outils/local_lib.php
@@ -143,7 +143,7 @@ class JSMin {
 
     public function __construct($input) {
         $this->input       = str_replace("\r\n", "\n", $input);
-        $this->inputLength = strlen($this->input);
+        $this->inputLength = mb_strlen($this->input,'UTF-8');
     }
 
     // -- Protected Instance Methods ---------------------------------------------

--- a/divers/outils/local_lib.php
+++ b/divers/outils/local_lib.php
@@ -580,7 +580,7 @@ class LoremIpsumGenerator {
 		
 	function getContent($count, $format = 'html', $loremipsum = true)
 	{
-		$format = strtolower($format);
+		$format = mb_strtolower($format,'UTF-8');
 		
 		if($count <= 0)
 			return '';

--- a/exemple/local_lib.php
+++ b/exemple/local_lib.php
@@ -13,6 +13,6 @@
  */
 
 function rename_example($data) {
-    return strtolower(microtime(TRUE).strrchr($_FILES[$data.'_tmp']['name'], '.'));
+    return mb_strtolower(microtime(TRUE).strrchr($_FILES[$data.'_tmp']['name'], '.'),'UTF-8');
 }
 ?>

--- a/include/lib/class_xml.php
+++ b/include/lib/class_xml.php
@@ -47,7 +47,7 @@ class gxml {
      */
 
     function _tag_open($parser, $tag, $attributes) {
-        $tag = strtolower($tag);
+        $tag = mb_strtolower($tag,'UTF-8');
         $attributes = array_change_key_case($attributes, CASE_LOWER);
         if($this->deport_parsing) {
 
@@ -56,7 +56,7 @@ class gxml {
                 $tab_attributes[] = $key.'="'.$value.'"';
             }
 
-            if(strtolower($tag) == 'br') {
+            if(mb_strtolower($tag,'UTF-8') == 'br') {
                 $this->deport_parsing .= '<br />';
             } else {
                 $this->deport_parsing .= '<'.$tag.' '.implode(' ',$tab_attributes).'>';
@@ -109,13 +109,13 @@ class gxml {
     }
 
     function _tag_close($parser, $tag) {
-        $tag = strtolower($tag);
+        $tag = mb_strtolower($tag,'UTF-8');
         if(in_array($tag, $this->exception)) {
             $this->node[$this->current_node]['cdata'] = $this->deport_parsing;
             $this->deport_parsing = FALSE;
         }
         if($this->deport_parsing) {
-            if(strtolower($tag) != 'br') {
+            if(mb_strtolower($tag,'UTF-8') != 'br') {
                 $this->deport_parsing .= '</'.$tag.'>';
             }
         } else {

--- a/include/lib/class_xml.php
+++ b/include/lib/class_xml.php
@@ -227,7 +227,7 @@ class gxml {
         $result = array();
         if(count($this->node)) {
             foreach($this->node as $index => $element) {
-                if(strtoupper($element['tag']) == strtoupper($tag_name)) {
+                if(mb_strtoupper($element['tag'],'UTF-8') == mb_strtoupper($tag_name,'UTF-8')) {
                     $correct = TRUE;
                     if(is_array($attr) && count($attr)) {
                         foreach($attr as $id => $value) {

--- a/include/lib/export/pdf.php
+++ b/include/lib/export/pdf.php
@@ -74,7 +74,7 @@ class PDF extends FPDF{
             $w=$this->w-$this->rMargin-$this->x;
         $wmax=($w-2*$this->cMargin)*1000/$this->FontSize;
         $s=str_replace("\r",'',$txt);
-        $nb=strlen($s);
+        $nb=mb_strlen($s,'UTF-8');
         if($nb>0 and $s[$nb-1]=="\n")
             $nb--;
         $sep=-1;

--- a/include/lib/lib_backoffice.php
+++ b/include/lib/lib_backoffice.php
@@ -408,7 +408,7 @@ function backoffice_kernel($structure, $db) {
 
                             $tmp.=$tmp_separator;
                         }
-                        //$tmp=substr($tmp, 0, -(strlen($tmp_separator)));
+                        //$tmp=substr($tmp, 0, -(mb_strlen($tmp_separator,'UTF-8')));
                     break;
                     case 'alpha' :
                         for($loop=65;$loop<91;$loop++) {
@@ -421,7 +421,7 @@ function backoffice_kernel($structure, $db) {
 
                             $tmp.=$tmp_separator;
                         }
-                        //$tmp=substr($tmp, 0, -(strlen($tmp_separator)));
+                        //$tmp=substr($tmp, 0, -(mb_strlen($tmp_separator,'UTF-8')));
                     break;
                     case 'liste' :
                     
@@ -439,7 +439,7 @@ function backoffice_kernel($structure, $db) {
                         
                         $tmp.="</form>\n";
 
-                        //$tmp=substr($tmp, 0, -(strlen($tmp_separator)));
+                        //$tmp=substr($tmp, 0, -(mb_strlen($tmp_separator,'UTF-8')));
                     break;
                     case 'select' :
                         $tmp.= "<form class=\"form-inline\" action=\"".$session->url($script['name'])."\">\n";
@@ -549,11 +549,11 @@ function backoffice_kernel($structure, $db) {
             }
 
             if($session_context['logical'][$i]!='')
-                $tmp=substr($tmp, 0, -(strlen($session_context['logical'][$i])));
+                $tmp=substr($tmp, 0, -(mb_strlen($session_context['logical'][$i],'UTF-8')));
             $tmp_where_complement.='('.$tmp.') '.$config['logical'].' ';
         }
 
-        $tmp_where_complement=substr($tmp_where_complement, 0, -(strlen($config['logical'])+1));
+        $tmp_where_complement=substr($tmp_where_complement, 0, -(mb_strlen($config['logical'],'UTF-8')+1));
 
         if($tmp_where_complement!='') {
             if(isset($tmp_where[1]))

--- a/include/lib/lib_backoffice.php
+++ b/include/lib/lib_backoffice.php
@@ -1141,7 +1141,7 @@ function backoffice_kernel($structure, $db) {
                 if($rowspan===TRUE) {   // Si rowspan
                     if(isset($foo[$key][$dat['field']])) {
                         if($dat['field'][0]!='_')
-                            $cellule_value=htmlspecialchars(strip_tags($foo[$key][$dat['field']]), ENT_QUOTES);
+                            $cellule_value=htmlspecialchars(strip_tags($foo[$key][$dat['field']]), ENT_QUOTES, 'UTF-8');
                         else
                             $cellule_value=$foo[$key][$dat['field']];
                         $cellule_rowspan=$foo[$key][$dat['field'].'_rowspan'];
@@ -1160,7 +1160,7 @@ function backoffice_kernel($structure, $db) {
                 else {  // Si pas de rowspan
                     if($val[$dat['field']]!='') {
                         if($dat['field'][0]!='_')
-                            $flux_data.="<td data-field=\"".$dat['field']."\">".htmlspecialchars(strip_tags($val[$dat['field']]), ENT_QUOTES)."</td>\n";
+                            $flux_data.="<td data-field=\"".$dat['field']."\">".htmlspecialchars(strip_tags($val[$dat['field']]), ENT_QUOTES, 'UTF-8')."</td>\n";
                         else
                             $flux_data.="<td data-field=\"".$dat['field']."\">".$val[$dat['field']]."</td>\n";
                     }

--- a/include/lib/lib_backoffice.php
+++ b/include/lib/lib_backoffice.php
@@ -824,7 +824,7 @@ function backoffice_kernel($structure, $db) {
                 foreach($foo as $val) {
                     if(($val['type']=='global' || $val['type']=='local') && isset($config['help']['action'])) {
                         if(is_array($val['label']))
-                            $val['label']=implode(' '.strtolower(STR_OR).' ', $val['label']);
+                            $val['label']=implode(' '.mb_strtolower(STR_OR,'UTF-8').' ', $val['label']);
                         $tmp.=sprintf($config['help']['action'], $val['label'], mb_strtolower($val['label'], "UTF-8"));
                     }
                 }

--- a/include/lib/lib_backoffice.php
+++ b/include/lib/lib_backoffice.php
@@ -1451,8 +1451,8 @@ function backoffice_kernel($structure, $db) {
             if(isset($export['format']) && !empty($export['format'])) {
                 $format='';
                 foreach($export['format'] as $value) {
-                    if (defined('STR_BACKOFFICE_EXPORT_FORMAT_'.strtoupper($value)))
-                        $texte_format=constant('STR_BACKOFFICE_EXPORT_FORMAT_'.strtoupper($value));
+                    if (defined('STR_BACKOFFICE_EXPORT_FORMAT_'.mb_strtoupper($value,'UTF-8')))
+                        $texte_format=constant('STR_BACKOFFICE_EXPORT_FORMAT_'.mb_strtoupper($value,'UTF-8'));
                     else
                         $texte_format=$value;
 

--- a/include/lib/lib_backoffice.php
+++ b/include/lib/lib_backoffice.php
@@ -1241,7 +1241,7 @@ function backoffice_kernel($structure, $db) {
                                         $tmp.=sprintf($act['js'], $b[$act['on']]);
                                     else {
                                         foreach($act['on'] as $on) {
-                                            $act['js']=preg_replace('/%s/', addslashes(htmlentities($val[$on])), $act['js'], 1);
+                                            $act['js']=preg_replace('/%s/', addslashes(htmlentities($val[$on], ENT_COMPAT, 'UTF-8')), $act['js'], 1);
                                         }
                                         $tmp.=$act['js'];
                                     }

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -525,7 +525,7 @@ function add_upload($data) {
         if(function_exists($_FILES[$data.'_tmp']['rename']))
             $final_name=call_user_func($_FILES[$data.'_tmp']['rename'], $data);
         else
-            $final_name = strtolower(uniqid('').strrchr($_FILES[$data.'_tmp']['name'], '.'));
+            $final_name = mb_strtolower(uniqid('').strrchr($_FILES[$data.'_tmp']['name'], '.'),'UTF-8');
 
         // On supprime eventuellement l'ancien fichier
 

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -645,7 +645,7 @@ function date_iso_to($date_iso, $format="d-m-Y H:i:s") {
 
 function date_to_iso($date, $format="d-m-Y H:i:s") {
     $j = 0;
-    for($i = 0; $i < strlen($format); $i++){
+    for($i = 0; $i < mb_strlen($format,'UTF-8'); $i++){
         switch($format{$i}){
             case 'Y' :  $date_iso['Y'] = $date{$j++};
                         $date_iso['Y'].= $date{$j++};
@@ -719,10 +719,10 @@ function abstract_string($param) {
 
     // Correction Armel (22/03/2004)
 
-    if (strlen($string) < $length)
+    if (mb_strlen($string,'UTF-8') < $length)
         return $string;
     else
-        $length = strlen($string);
+        $length = mb_strlen($string,'UTF-8');
 
     $length--;
     while (!in_array($string[$length],$liste) && $length!==0)

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -473,7 +473,7 @@ function get_url($url, $name='', $value='') {
             // Protection xss
             //
             strip_tags($v);
-            $v=htmlspecialchars($v, ENT_QUOTES);
+            $v=htmlspecialchars($v, ENT_QUOTES, 'UTF-8');
 
             if($k==$name) {
                 $flag=TRUE;
@@ -1195,9 +1195,9 @@ function check_bo($acl, $ressource) {
 
 function clean_string($string, $strip_tags=TRUE) {
     if ($strip_tags)
-        return htmlspecialchars(strip_tags($string), ENT_QUOTES);
+        return htmlspecialchars(strip_tags($string), ENT_QUOTES, 'UTF-8');
     else
-        return htmlspecialchars($string, ENT_QUOTES);
+        return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
 }
 
 /*

--- a/include/lib/lib_debug.php
+++ b/include/lib/lib_debug.php
@@ -156,7 +156,7 @@ function debug_get_info($value) {
     global $session;
             
     $titre=$value;    
-    $value=strtolower($value);
+    $value=mb_strtolower($value,'UTF-8');
 
     if($value=='get')
         $foo=print_r($_GET, true);

--- a/include/lib/lib_debug.php
+++ b/include/lib/lib_debug.php
@@ -245,7 +245,7 @@ function debug_print_console($get_defined_vars) {
     list($usec, $sec) = explode(" ", microtime());
     $time_end=((float)$usec + (float)$sec);
     
-    $page_size=strlen(ob_get_contents());
+    $page_size=mb_strlen(ob_get_contents(),'UTF-8');
     
     $database=debug_get_database();
 

--- a/include/lib/lib_form.php
+++ b/include/lib/lib_form.php
@@ -215,7 +215,7 @@ function form_parser($structure, $visu = FALSE) {
                     $value = $structure[$k]['value'];
                     if(isset($structure[$k]['type']) && $structure[$k]['type'] == 'password'){
                         if($structure[$k]['value'] != ''){
-                            $value = str_repeat('*', strlen($structure[$k]['value']));
+                            $value = str_repeat('*', mb_strlen($structure[$k]['value'],'UTF-8'));
                         }
                     }
                     if($k[0]!='_')          // Le _ identifie un champ potentiellement dangereux et sujet aux xss
@@ -315,7 +315,7 @@ function form_parser($structure, $visu = FALSE) {
 
         foreach($structure_visu as $name => $element) {
             if($element['item'] == 'info') {
-                $tpl_length=strlen($element['tpl']);
+                $tpl_length=mb_strlen($element['tpl'],'UTF-8');
                 if($element['tpl'][0]=='[' && $element['tpl'][$tpl_length-1]==']') {
                     $structure_visu['view_back']['tpl'] = $element['tpl'];
                     break;
@@ -795,7 +795,7 @@ function form_parser($structure, $visu = FALSE) {
                     // Cas des optgroup
                     if(isset($optgroup) && $optgroup==TRUE && (isset($key[0]) && $key[0]=='<'))
                         $form_tmp.=sprintf(" <optgroup label=\"%s\">\n", $val);
-                    elseif(isset($optgroup) && $optgroup==TRUE && (isset($key[strlen($key)-1]) && $key[strlen($key)-1]=='>'))
+                    elseif(isset($optgroup) && $optgroup==TRUE && (isset($key[mb_strlen($key,'UTF-8')-1]) && $key[mb_strlen($key,'UTF-8')-1]=='>'))
                         $form_tmp.=sprintf(" </optgroup>\n");
                     else {
                         // Pour les selects simples

--- a/include/lib/lib_test.php
+++ b/include/lib/lib_test.php
@@ -265,7 +265,7 @@ function test_date_time($input) {
     $sep  = substr($input, 10, 1);
     $time = substr($input, 11, 8);
 
-    if (strlen($input) == 19 && test_date($date) && $sep == ' ' && test_iso_time($time))
+    if (mb_strlen($input,'UTF-8') == 19 && test_date($date) && $sep == ' ' && test_iso_time($time))
         return TRUE;
     else
         return FALSE;
@@ -289,7 +289,7 @@ function test_iso_date_time($input) {
     $sep  = substr($input, 10, 1);
     $time = substr($input, 11, 8);
 
-    if (strlen($input) == 19 && test_iso_date($date) && $sep == ' ' && test_iso_time($time))
+    if (mb_strlen($input,'UTF-8') == 19 && test_iso_date($date) && $sep == ' ' && test_iso_time($time))
         return TRUE;
     else
         return FALSE;

--- a/include/lib/lib_test.php
+++ b/include/lib/lib_test.php
@@ -42,19 +42,19 @@ function test_upload($name, $element) {
         $erreur[]=STR_FORM_E_FATAL_UPLOAD_CANT_WRITE;
 
     // Type Mime incorrect
-    if(isset($element['type']) && !empty($element['type']) && !in_array(strtolower($_FILES[$name.'_tmp']['type']), $element['type'])) {
+    if(isset($element['type']) && !empty($element['type']) && !in_array(mb_strtolower($_FILES[$name.'_tmp']['type'],'UTF-8'), $element['type'])) {
         if(sizeof($element['type'])>1)
-            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_TYPE, strtolower($_FILES[$name.'_tmp']['type']), 's', 's', implode(', ', $element['type']));
+            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_TYPE, mb_strtolower($_FILES[$name.'_tmp']['type'],'UTF-8'), 's', 's', implode(', ', $element['type']));
         else
-            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_TYPE, strtolower($_FILES[$name.'_tmp']['type']), '', '', implode(', ', $element['type']));
+            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_TYPE, mb_strtolower($_FILES[$name.'_tmp']['type'],'UTF-8'), '', '', implode(', ', $element['type']));
     }
 
     // Type Mime incorrect
-    if(isset($element['extension']) && !empty($element['extension']) && !in_array(strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1)), $element['extension'])) {
+    if(isset($element['extension']) && !empty($element['extension']) && !in_array(mb_strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1),'UTF-8'), $element['extension'])) {
         if(sizeof($element['extension'])>1)
-            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_EXT, '.'.strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1)), 's', 's', '.'.implode(', .', $element['extension']));
+            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_EXT, '.'.mb_strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1),'UTF-8'), 's', 's', '.'.implode(', .', $element['extension']));
         else
-            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_EXT, '.'.strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1)), '', '', '.'.implode(', .', $element['extension']));
+            $erreur[]=sprintf(STR_FORM_E_FATAL_UPLOAD_BAD_EXT, '.'.mb_strtolower(substr(strrchr($_FILES[$name.'_tmp']['name'], '.'), 1),'UTF-8'), '', '', '.'.implode(', .', $element['extension']));
     }
 
     // Si pas d'erreur, on complète la structure $_FILES par divers éléments

--- a/onglet/index.php
+++ b/onglet/index.php
@@ -277,7 +277,7 @@ if(!empty($_GET['action']))
                     $sql = 'actif =     '.$db->qstr($_POST['actif']).', ';
                     $sql.= 'acl =       '.$db->qstr($_POST['acl']).', ';
                     $sql.= 'poste =     '.$db->qstr($_POST['poste']).', ';
-                    $sql.= 'nom =       '.$db->qstr(strtoupper(delete_accent($_POST['nom']))).', ';
+                    $sql.= 'nom =       '.$db->qstr(mb_strtoupper(delete_accent($_POST['nom'],'UTF-8'))).', ';
                     $sql.= 'prenom =    '.$db->qstr($_POST['prenom']).', ';
 
                     if(!empty($_POST['password'])) {

--- a/profil.php
+++ b/profil.php
@@ -216,7 +216,7 @@ if(!empty($_GET['action'])) {
                         if(!empty($_POST['password'])) {
                             $sql.= 'password = '.$db->qstr(hash('sha512', $_POST['password'])).', ';
                         }
-                        $sql.= 'nom = 		'.$db->qstr(strtoupper(delete_accent($_POST['nom']))).', ';
+                        $sql.= 'nom = 		'.$db->qstr(mb_strtoupper(delete_accent($_POST['nom']),'UTF-8')).', ';
                         $sql.= 'prenom = 	'.$db->qstr($_POST['prenom']).', ';
                         $sql.= 'theme = 	'.$db->qstr($_POST['theme']).', ';
                         $sql.= 'langue = 	'.$db->qstr($_POST['langue']).' ';

--- a/reset.php
+++ b/reset.php
@@ -154,7 +154,7 @@ if(!empty($_GET['action'])) {
                                 if(preg_match('/[^a-zA-Z0-9]/',$_POST['password']))
                                     $form_error['fatal']['password'][] = STR_UTILISATEUR_E_FATAL_1;
 
-                                if(strlen($_POST['password'])<4)
+                                if(mb_strlen($_POST['password'],'UTF-8')<4)
                                     $form_error['fatal']['password'][] = STR_UTILISATEUR_E_FATAL_2;
                             }
                         }

--- a/utilisateur/prenom.php
+++ b/utilisateur/prenom.php
@@ -14,7 +14,7 @@ if (!$q) return;
 $tableau = file('../data/prenom.dat');
 
 foreach ($tableau as $key=>$value) {
-    if (strpos(strtolower($value), $q) !== FALSE) {
+    if (strpos(mb_strtolower($value,'UTF-8'), $q) !== FALSE) {
         echo "$value\n";
     }
 }

--- a/utilisateur/simple.php
+++ b/utilisateur/simple.php
@@ -359,7 +359,7 @@ if(!empty($_GET['action']))
                     $sql = 'actif =     '.$db->qstr($_POST['actif']).', ';
                     $sql.= 'acl =       '.$db->qstr($_POST['acl']).', ';
                     $sql.= 'poste =     '.$db->qstr($_POST['poste']).', ';
-                    $sql.= 'nom =       '.$db->qstr(strtoupper(delete_accent($_POST['nom']))).', ';
+                    $sql.= 'nom =       '.$db->qstr(mb_strtoupper(delete_accent($_POST['nom']),'UTF-8')).', ';
                     $sql.= 'prenom =    '.$db->qstr($_POST['prenom']).', ';
                     $sql.= 'email =     '.$db->qstr($_POST['email']).', ';
 

--- a/utilisateur/split_bo.php
+++ b/utilisateur/split_bo.php
@@ -79,7 +79,7 @@ $structure= array(
     ',
 );
 
-//echo strlen(backoffice($structure));
+//echo mb_strlen(backoffice($structure),'UTF-8');
 $foo=backoffice($structure);
 
 //

--- a/utilisateur/split_form.php
+++ b/utilisateur/split_form.php
@@ -324,7 +324,7 @@ switch ($_GET['action'])
                 $sql = 'actif =     '.$db->qstr($_POST['actif']).', ';
                 $sql.= 'acl =       '.$db->qstr($_POST['acl']).', ';
                 $sql.= 'poste =     '.$db->qstr($_POST['poste']).', ';
-                $sql.= 'nom =       '.$db->qstr(strtoupper(delete_accent($_POST['nom']))).', ';
+                $sql.= 'nom =       '.$db->qstr(mb_strtoupper(delete_accent($_POST['nom']),'UTF-8')).', ';
                 $sql.= 'prenom =    '.$db->qstr($_POST['prenom']).', ';
                 $sql.= 'email =     '.$db->qstr($_POST['email']).', ';
                 $sql.= 'couleur =   '.$db->qstr(implode('|',$_POST['couleur'])).', ';


### PR DESCRIPTION
Adaptation pour une meilleure prise en compte de l'utf-8 (à l'exclusion des librairies externes comme adodb, fpdf, etc.) : 
- remplacement de strlen, strtoupper, strtolower par mb_strlen, mb_strtoupper, mb_strtolower
- ajout de paramètres dans les appels a htmlentities et htmlspecialchars
