### PR TITLE
Feature - Ajout de la possibilité de debrayer les view_back dans la brique form

### DIFF
--- a/include/lib/lib_form.php
+++ b/include/lib/lib_form.php
@@ -123,6 +123,7 @@ function form_parser($structure, $visu = FALSE) {
     // On retravaille le tableau $structure afin de présenter uniquement des champs de type info
 
     if($visu){
+        $is_view_back=TRUE;
         $structure_visu=array();
         foreach($structure as $k => $v){
 
@@ -286,10 +287,25 @@ function form_parser($structure, $visu = FALSE) {
                     break;
 
                 case 'form' :
-                case 'hidden' :
-                case 'button' :
-
+                    if (isset($structure[$k]['view_back']) && $structure[$k]['view_back'] === FALSE){
+                        $is_view_back=FALSE;
+                    }
+                    
                     unset($structure[$k]);
+                    break;
+                    
+                case 'hidden' :
+                    unset($structure[$k]);
+                    break;
+                    
+                case 'button' :
+                    if (isset($structure[$k]['view']) && $structure[$k]['view'] === TRUE) {
+                        $is_view_back=FALSE;
+                    }
+                    else {
+                        unset($structure[$k]);
+                    }
+                    break;
             }
             if(isset($structure[$k]['value']) && $structure[$k]['item'] != 'upload'){
                 $structure[$k]['value'].= ' ';
@@ -302,29 +318,34 @@ function form_parser($structure, $visu = FALSE) {
             }
         }
 
-        // Construction du bouton de retour
+        // Traitement éventuel du bouton de retour
+        
+        if ($is_view_back === TRUE){
+        
+            // Construction du bouton de retour
 
-        $structure_visu['view_back'] = array(
-            'item' => 'button',
-            'value' => STR_RETOUR,
-            'type' => 'button',
-            'js' => 'onclick="window.location=\''.$session->url($_SERVER['PHP_SELF']).'\'"',
-        );
+            $structure_visu['view_back'] = array(
+                'item' => 'button',
+                'value' => STR_RETOUR,
+                'type' => 'button',
+                'js' => 'onclick="window.location=\''.$session->url($_SERVER['PHP_SELF']).'\'"',
+            );
 
-        // Recherche d'un tpl eligible pour formater le bouton de retour
+            // Recherche d'un tpl eligible pour formater le bouton de retour
 
-        foreach($structure_visu as $name => $element) {
-            if($element['item'] == 'info') {
-                $tpl_length=mb_strlen($element['tpl'],'UTF-8');
-                if($element['tpl'][0]=='[' && $element['tpl'][$tpl_length-1]==']') {
-                    $structure_visu['view_back']['tpl'] = $element['tpl'];
-                    break;
+            foreach($structure_visu as $name => $element) {
+                if($element['item'] == 'info') {
+                    $tpl_length=mb_strlen($element['tpl'],'UTF-8');
+                    if($element['tpl'][0]=='[' && $element['tpl'][$tpl_length-1]==']') {
+                        $structure_visu['view_back']['tpl'] = $element['tpl'];
+                        break;
+                    }
+                    else
+                        $structure_visu['view_back']['tpl'] = '[(2){libelle}(8){form}(2){legende}]';
                 }
-                else
-                    $structure_visu['view_back']['tpl'] = '[(2){libelle}(8){form}(2){legende}]';
             }
         }
-
+        
         // print_rh($structure_visu);
 
         $structure=$structure_visu;


### PR DESCRIPTION
Ajout de possibilité de désactiver le comportement d'ajout automatique du bouton de retour en visualisation d'une brique form et de pouvoir ajouter des boutons spécifiques.

Éléments de structures ajoutés : 
- La présence de la clé "view_back" dans l'item "form" est vérifiée lorsqu'on est en visualisation. Si celle-ci est présente et strictement égale à FALSE, l'ajout du bouton "view_back" est désactivé
- La présence de la clé "view" dans un item "button" est vérifiée lorsqu'on est en visualisation. Si celle-ci est présente et strictement égale à TRUE, la suppression du bouton n'a pas lieu et l'ajout du bouton "view_back" est désactivé

Cette nouvelle fonctionnalité est neutre et transparente en terme de reprise : les clés ajoutées sont facultatives, le comportement des applications reste totalement inchangé si celles-ci ne sont pas présentes.
