### PR TITLE
Feature - Mise en cohérence du comportement obtenu en cas d'échec de connexion à la base de données

### DIFF
--- a/include/lib/adodb_carbone/drivers/mssql.php
+++ b/include/lib/adodb_carbone/drivers/mssql.php
@@ -10,12 +10,16 @@ class ADODB_mssql extends ADOConnection{
         $this->link = mssql_connect($hostname, $username, $password);
 
         if(!$this->link){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
 
         if(!mssql_select_db($database_name, $this->link)){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
+        
+        return TRUE;
     }
 
     function Execute($sql){

--- a/include/lib/adodb_carbone/drivers/mysql.php
+++ b/include/lib/adodb_carbone/drivers/mysql.php
@@ -10,12 +10,16 @@ class ADODB_mysql extends ADOConnection{
         $this->link = mysql_connect($hostname, $username, $password, true);
 
         if(!$this->link){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
 
         if(!mysql_select_db($database_name, $this->link)){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
+        
+        return TRUE;
     }
 
     function Execute($sql){

--- a/include/lib/adodb_carbone/drivers/mysqli.php
+++ b/include/lib/adodb_carbone/drivers/mysqli.php
@@ -9,8 +9,11 @@ class ADODB_mysqli extends ADOConnection{
 
     function Connect($hostname, $username, $password, $database_name){
         if(!($this->link = mysqli_connect($hostname, $username, $password, $database_name))){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
+        
+        return TRUE;
     }
 
     function Execute($sql){

--- a/include/lib/adodb_carbone/drivers/postgres.php
+++ b/include/lib/adodb_carbone/drivers/postgres.php
@@ -10,8 +10,11 @@ class ADODB_postgres extends ADOConnection{
         $this->link = pg_connect('host='.$hostname.' port=5432 dbname='.$database_name.' user='.$username.' password='.$password);
 
         if(!$this->link){
-            exit($this->ErrorMsg());
+           echo $this->ErrorMsg();
+           return FALSE;
         }
+        
+        return TRUE;
     }
 
     function Execute($sql){

--- a/include/lib/adodb_carbone/drivers/sqlite.php
+++ b/include/lib/adodb_carbone/drivers/sqlite.php
@@ -10,8 +10,11 @@ class ADODB_sqlite extends ADOConnection{
         $this->link = sqlite_open($hostname);
 
         if(!$this->link){
-            exit($this->ErrorMsg());
+            echo $this->ErrorMsg();
+            return FALSE;
         }
+        
+        return TRUE;
     }
 
     function Execute($sql){

--- a/include/open.php
+++ b/include/open.php
@@ -1,12 +1,12 @@
 <?php
 //
-// Ouvertue de la connexion SGBD
+// Ouverture de la connexion SGBD
 //
 
 $db =ADONewConnection(CFG_TYPE);
-$db->connect(CFG_HOST, CFG_USER, CFG_PASS, CFG_BASE);
+$indicateur_db = $db->connect(CFG_HOST, CFG_USER, CFG_PASS, CFG_BASE);
 
-if(!$db){
+if($indicateur_db === FALSE){
     die("Pas de connexion");
 }
 


### PR DESCRIPTION
Le comportement obtenu en cas d'échec de la connexion à la base de données était différent en fonction qu'on ait choisi la classe "adodb" ou la classe "adodb_carbone". 

Les drivers SGDB de la classe "adodb" renvoient seulement un booléen pour indiquer le statut de la connexion à la base de données alors que ceux de la classe "adodb_carbone" font directement un exit.

On n'entrait jamais dans le cas du test (!$db), quelque soit la classe choisie. Et le traçage de l'échec de connexion était inopérant avec la classe "adodb".

Adaptations effectuées :
- Mise en cohérence du comportement des drivers SGDB de la classe "adodb_carbone" avec ceux de la classe "adodb" en cas d'échec de connexion
- Mise en place d'un test fonctionnel sur l'échec de connexion à la base de données, avec affichage d'un message textuel brut
