### PR TITLE
Bugfix - Retablissement de la rétro-compatibilité avec PHP5.4 sur l'interception des emails

### DIFF
--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -778,7 +778,7 @@ function delete_accent($chaine) {
  */
 function email($to, $subject, $message, $type='text', $header='', $param='', $pj = array()) {
     // Interception de l'email si la constante CFG_EMAIL_INTERCEPTION est définie et non vide dans la config
-    if (defined('CFG_EMAIL_INTERCEPTION') && !empty(CFG_EMAIL_INTERCEPTION) && filter_var(CFG_EMAIL_INTERCEPTION, FILTER_VALIDATE_EMAIL)) {
+    if (defined('CFG_EMAIL_INTERCEPTION') && CFG_EMAIL_INTERCEPTION != '' && filter_var(CFG_EMAIL_INTERCEPTION, FILTER_VALIDATE_EMAIL)) {
         $to = CFG_EMAIL_INTERCEPTION;
     }
 


### PR DESCRIPTION
Le morceau d'instruction !empty(CFG_EMAIL_INTERCEPTION) présent dans la fonction email entraîne une parse error si on utilise Carbone avec PHP 5.4. 

Je conviens qu'il s'agit d'une version obsolète de PHP, mais la correction correspondante simplifie le code préexistant et reste neutre, le coût de rétablir la rétro-compatibilité serait quasi-nul.
