### PR TITLE
Feature amelioration growl

### DIFF
--- a/include/config/config.php
+++ b/include/config/config.php
@@ -97,7 +97,8 @@ define ('CFG_TITRE', 'Carbone');                                            // T
 define ('CFG_VERSION', '5.3.003');                                          // Version de l'application
 define ('CFG_VERSION_CARBONE', '5.3.003 Mercure');                          // Version de Carbone
 define ('CFG_DATE', '27/09/2016');                                          // Date de dernières révision de l'application
-define ('CFG_EMAIL', 'armel.fauveau@globalis-ms.com');                        // Email générique de contact
+define ('CFG_EMAIL', 'armel.fauveau@globalis-ms.com');                      // Email générique de contact
+define ('CFG_GROWL_DELAY', '');                                             // Délai d'affichage des messages avec growl
 
 define ('CFG_GLOBALIS_TITRE', 'GLOBALIS media systems');                                        // Globalis Titre
 define ('CFG_GLOBALIS_HTTP', 'http://www.globalis-ms.com');                                     // Globalis Url

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -1352,6 +1352,13 @@ function growl() {
 
     if(!empty($growl)) {
         $is_load_growl=FALSE;
+        
+        if (defined('CFG_GROWL_DELAY') && CFG_GROWL_DELAY != ''){
+            $delai_growl=CFG_GROWL_DELAY;
+        }
+        else {
+            $delai_growl=5000;
+        }
         foreach($growl as $key => $value) {
             $tmp='';
 
@@ -1391,7 +1398,7 @@ function growl() {
                       offset: {from: "top", amount: 20},
                       align: "right",
                       width: "auto",
-                      delay: 5000,
+                      delay: '.$delai_growl.',
                       allow_dismiss: true,
                       stackup_spacing: 10
                     });

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -1351,6 +1351,7 @@ function growl() {
     $growl=$session->get_var('growl');
 
     if(!empty($growl)) {
+        $is_load_growl=FALSE;
         foreach($growl as $key => $value) {
             $tmp='';
 
@@ -1374,9 +1375,15 @@ function growl() {
 
             else
                 $tmp="<p>".$value['message']."</p>";
-
+            
+            if (!$is_load_growl){
+                echo '
+                    <script type="text/javascript" src="'.CFG_PATH_HTTP_WEB.'/js/growl/bootstrap.growl.min.js"></script>
+                ';
+                $is_load_growl=TRUE;
+            }
+            
             echo '
-                <script type="text/javascript" src="'.CFG_PATH_HTTP_WEB.'/js/growl/bootstrap.growl.min.js"></script>
                 <script type="text/javascript"><!--
                     $.bootstrapGrowl("<span class=\"label label-'.$value['label'].'\">'.$value['libelle'].'</span>'.$tmp.'", {
                       ele: "body",


### PR DESCRIPTION
Deux adaptations faites :
1. Inclure le script JS de base pour growl uniquement une seule fois
2. Permettre de régler la durée d'affichage des messages

L'adaptation est neutre par rapport aux projets préexistants : le comportement antérieur est conservé sans changement si la fonctionnalité en question n'est pas activée.

Demande de modification du délai d'affichage déjà rencontrée sur 3 projets distincts, pour 2 clients différents (hors TMA).

A ta disposition pour en discuter et/ou améliorer si nécessaire