### PR TITLE
Feature amelioration growl2

### DIFF
--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -1339,7 +1339,7 @@ function message($libelle, $message, $css='danger', $type='normal', $selecteur=T
  * -----
  *
  * -----
- *
+ * @return  string                              le flux HTML
  * -----
  * $Author: armel $
  * $Copyright: GLOBALIS media systems $
@@ -1348,6 +1348,8 @@ function message($libelle, $message, $css='danger', $type='normal', $selecteur=T
 function growl() {
     global $session;
 
+    $flux='';
+    
     $growl=$session->get_var('growl');
 
     if(!empty($growl)) {
@@ -1377,13 +1379,13 @@ function growl() {
                 $tmp="<p>".$value['message']."</p>";
             
             if (!$is_load_growl){
-                echo '
+                $flux.= '
                     <script type="text/javascript" src="'.CFG_PATH_HTTP_WEB.'/js/growl/bootstrap.growl.min.js"></script>
                 ';
                 $is_load_growl=TRUE;
             }
             
-            echo '
+            $flux.= '
                 <script type="text/javascript"><!--
                     $.bootstrapGrowl("<span class=\"label label-'.$value['label'].'\">'.$value['libelle'].'</span>'.$tmp.'", {
                       ele: "body",
@@ -1400,5 +1402,7 @@ function growl() {
         }
         $session->unregister('growl');
     }
+    
+    return $flux;
 }
 ?>

--- a/include/lib/lib_carbone.php
+++ b/include/lib/lib_carbone.php
@@ -1351,6 +1351,7 @@ function growl() {
     $growl=$session->get_var('growl');
 
     if(!empty($growl)) {
+        $is_load_growl=FALSE;
         foreach($growl as $key => $value) {
             $tmp='';
 
@@ -1374,9 +1375,15 @@ function growl() {
 
             else
                 $tmp="<p>".$value['message']."</p>";
-
+            
+            if (!$is_load_growl){
+                echo '
+                    <script type="text/javascript" src="'.CFG_PATH_HTTP_WEB.'/js/growl/bootstrap.growl.min.js"></script>
+                ';
+                $is_load_growl=TRUE;
+            }
+            
             echo '
-                <script type="text/javascript" src="'.CFG_PATH_HTTP_WEB.'/js/growl/bootstrap.growl.min.js"></script>
                 <script type="text/javascript"><!--
                     $.bootstrapGrowl("<span class=\"label label-'.$value['label'].'\">'.$value['libelle'].'</span>'.$tmp.'", {
                       ele: "body",

--- a/include/stop_html.php
+++ b/include/stop_html.php
@@ -3,7 +3,7 @@
 // Ajout du js de gestion des messages en session (growl)
 //
 
-growl();
+echo growl();
 
 //
 // Chargement du stop_html.php 


### PR DESCRIPTION
Deux adaptations faites :

1. Inclure le script JS de base pour growl uniquement une seule fois
2. Permettre de récupérer le flux en sortie de la fonction growl pour avoir plus facilement la main dessus

L'adaptation est neutre par rapport aux projets préexistants : le comportement antérieur est conservé sans changement.